### PR TITLE
Add another catalog info file

### DIFF
--- a/catalog-info-3.yaml
+++ b/catalog-info-3.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: sample-service-3
+  description: |
+    A service for testing Backstage functionality. Configured for Travis CI.
+  annotations:
+    travis-ci.com/repo-slug: RoadieHQ/sample-project
+spec:
+  type: service
+  owner: dtuite
+  lifecycle: experimental
+  implementsApis:
+    - sample-service


### PR DESCRIPTION
This third catalog info Backstage yaml adds an annotation for Travis CI which doesn't conflict with Circle CI or GitHub actions.