### PR TITLE
Add lifecycle and owner to API definition

### DIFF
--- a/api-info-1.yaml
+++ b/api-info-1.yaml
@@ -7,8 +7,10 @@ metadata:
     - unstable
 spec:
   type: openapi
+  lifecycle: production
+  owner: info@roadie.io
   definition: |
-    openapi: 3.0.3
+    openapi: "3.0.3"
     info:
       title: The Sample Service API
       version: 0.0.1


### PR DESCRIPTION
The [docs](https://backstage.io/docs/features/software-catalog/descriptor-format#kind-api) now describe these fields as required and I found I couldn't add the API to Backstage without them.