### PR TITLE
Switch implementsApis to providesApis

### DIFF
--- a/catalog-info-1.yaml
+++ b/catalog-info-1.yaml
@@ -15,5 +15,5 @@ spec:
   type: service
   owner: dtuite
   lifecycle: experimental
-  implementsApis:
+  providesApis:
     - sample-service

--- a/catalog-info-2.yaml
+++ b/catalog-info-2.yaml
@@ -12,5 +12,5 @@ spec:
   type: service
   owner: dtuite
   lifecycle: experimental
-  implementsApis:
+  providesApis:
     - sample-service

--- a/catalog-info-3.yaml
+++ b/catalog-info-3.yaml
@@ -10,5 +10,5 @@ spec:
   type: service
   owner: dtuite
   lifecycle: experimental
-  implementsApis:
+  providesApis:
     - sample-service

--- a/catalog-info-4.yaml
+++ b/catalog-info-4.yaml
@@ -14,5 +14,5 @@ spec:
   type: service
   owner: dtuite
   lifecycle: experimental
-  implementsApis:
+  providesApis:
     - sample-service

--- a/catalog-info-lighthouse.yaml
+++ b/catalog-info-lighthouse.yaml
@@ -13,5 +13,5 @@ spec:
   type: service
   owner: dtuite
   lifecycle: experimental
-  implementsApis:
+  providesApis:
     - sample-service


### PR DESCRIPTION
`implementsApis` was deprecated and replaced with `providesApis`. This change updates the catalog info files to match the current spec.

[Docs](https://backstage.io/docs/features/software-catalog/descriptor-format#specprovidesapis-optional)