### PR TITLE
Recommend to use URL reader in techdocs-ref

### DIFF
--- a/catalog-info-1.yaml
+++ b/catalog-info-1.yaml
@@ -9,7 +9,7 @@ metadata:
     github.com/project-slug: roadiehq/sample-service
     # The Sentry organization is stored in the app-config.yaml of the Backstage instance.
     sentry.io/project-slug: sample-service
-    backstage.io/techdocs-ref: dir:./
+    backstage.io/techdocs-ref: url:https://github.com/RoadieHQ/sample-service
     pagerduty.com/integration-key: 1cf15c07f6f440e0a8d65b7ce80be834
     snyk.io/org-name: dtuite
     snyk.io/project-ids: b6ab231c-a019-4def-a148-4a10a79d6302


### PR DESCRIPTION
Hey! Just thought I'd update this based on the recent developments. URL Reader is much faster and will be the way to go forward. :)

https://github.com/backstage/backstage/blob/a034569199aa59830aad18e2b6ea91253d8dbc70/plugins/scaffolder-backend/sample-templates/docs-template/%7B%7Bcookiecutter.component_id%7D%7D/catalog-info.yaml\#L8